### PR TITLE
Fix sdist not being installable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Just a MANIFEST.in that includes README.md, so installs from pypi (or sdist itself) will now work.
