### PR TITLE
Fix Python 3 has no types.ClassType

### DIFF
--- a/fuckit.py
+++ b/fuckit.py
@@ -107,6 +107,7 @@ class _fuckit(types.ModuleType):
             basestring = str
             get_func_code = lambda f: f.__code__
             exec_ = __builtins__['exec']
+            types.ClassType = type
         else:
             basestring = __builtins__['basestring']
             get_func_code = lambda f: f.func_code


### PR DESCRIPTION
`examples.py` failed on Python 3 because `types.ClassType` has been replaced with `type`. 