### PR TITLE
Hint that the readme content is markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     tests_require=['nose'],
     description='The Python Error Steamroller',
     long_description=long_description,
+    long_description_content_type="text/markdown",
     platforms='any',
     test_suite='nose.collector',
     classifiers=[


### PR DESCRIPTION
This fixes the rendering on pypi.org, which currently doesn't attempt to parse it as markdown, thinking it's just plain text.

See https://pypi.org/project/fuckit/ for the issue